### PR TITLE
Fixed incorrect argument: changed `dims` to `dim`

### DIFF
--- a/ModernTCN-Long-term-forecasting/models/ModernTCN.py
+++ b/ModernTCN-Long-term-forecasting/models/ModernTCN.py
@@ -93,8 +93,8 @@ class ReparamLargeKernelConv(nn.Module):
         else:
             pad_left = torch.ones(D_out, D_in, pad_length_left) * pad_values
             pad_right = torch.ones(D_out, D_in, pad_length_right) * pad_values
-        x = torch.cat([pad_left,x],dims=-1)
-        x = torch.cat([x,pad_right],dims=-1)
+        x = torch.cat([pad_left,x],dim=-1)
+        x = torch.cat([x,pad_right],dim=-1)
         return x
 
     def get_equivalent_kernel_bias(self):

--- a/ModernTCN-classification/models/ModernTCN.py
+++ b/ModernTCN-classification/models/ModernTCN.py
@@ -95,8 +95,8 @@ class ReparamLargeKernelConv(nn.Module):
         else:
             pad_left = torch.ones(D_out, D_in, pad_length_left) * pad_values
             pad_right = torch.ones(D_out, D_in, pad_length_right) * pad_values
-        x = torch.cat([pad_left,x],dims=-1)
-        x = torch.cat([x,pad_right],dims=-1)
+        x = torch.cat([pad_left,x],dim=-1)
+        x = torch.cat([x,pad_right],dim=-1)
         return x
 
     def get_equivalent_kernel_bias(self):

--- a/ModernTCN-detection/models/ModernTCN.py
+++ b/ModernTCN-detection/models/ModernTCN.py
@@ -97,8 +97,8 @@ class ReparamLargeKernelConv(nn.Module):
         else:
             pad_left = torch.ones(D_out, D_in, pad_length_left) * pad_values
             pad_right = torch.ones(D_out, D_in, pad_length_right) * pad_values
-        x = torch.cat([pad_left,x],dims=-1)
-        x = torch.cat([x,pad_right],dims=-1)
+        x = torch.cat([pad_left,x],dim=-1)
+        x = torch.cat([x,pad_right],dim=-1)
         return x
 
     def get_equivalent_kernel_bias(self):

--- a/ModernTCN-imputation/models/ModernTCN.py
+++ b/ModernTCN-imputation/models/ModernTCN.py
@@ -91,8 +91,8 @@ class ReparamLargeKernelConv(nn.Module):
         else:
             pad_left = torch.ones(D_out, D_in, pad_length_left) * pad_values
             pad_right = torch.ones(D_out, D_in, pad_length_right) * pad_values
-        x = torch.cat([pad_left,x],dims=-1)
-        x = torch.cat([x,pad_right],dims=-1)
+        x = torch.cat([pad_left,x],dim=-1)
+        x = torch.cat([x,pad_right],dim=-1)
         return x
 
     def get_equivalent_kernel_bias(self):

--- a/ModernTCN-short-term/models/ModernTCN.py
+++ b/ModernTCN-short-term/models/ModernTCN.py
@@ -95,8 +95,8 @@ class ReparamLargeKernelConv(nn.Module):
         else:
             pad_left = torch.ones(D_out, D_in, pad_length_left) * pad_values
             pad_right = torch.ones(D_out, D_in, pad_length_right) * pad_values
-        x = torch.cat([pad_left,x],dims=-1)
-        x = torch.cat([x,pad_right],dims=-1)
+        x = torch.cat([pad_left,x],dim=-1)
+        x = torch.cat([x,pad_right],dim=-1)
         return x
 
     def get_equivalent_kernel_bias(self):


### PR DESCRIPTION
I'd like to express my gratitude to the author for making your invaluable work open-source.

But when employing structure reparameterization on ModernTCN, the following error arises:
```
TypeError: cat() received an invalid combination of arguments - got (list, dims=int), but expected one of:
* (tuple of Tensors tensors, int dim, *, Tensor out)
* (tuple of Tensors tensors, name dim, *, Tensor out)
```
The bug is located in the `PaddingTwoEdge1d` method of the `ReparamLargeKernelConv `class. However, it erroneously employs the argument name `dims` instead of `dim` when invoking `torch.cat`, leading to this TypeError.